### PR TITLE
chore: compliance with github changes

### DIFF
--- a/releases-action
+++ b/releases-action
@@ -61,4 +61,4 @@ echo ${JSON_STRING}
 OUTPUT=$(curl --silent --header "Authorization: token ${GITHUB_TOKEN}" --data "${JSON_STRING}" "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases")
 echo ${OUTPUT} | jq
 
-echo ::set-output name=release_tag::${TAG}
+echo "release_tag=${TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR updates the output tag to the new output format removing the old deprecated and soon to be disabled set-output method and removes the warning notifications that this action emits.

GitHub Advisory: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)