### PR TITLE
Update README and write permissions on build GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,12 @@ on: push
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Create Release

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ on:
 
 jobs:
   create-release:
-    permissions: write-all
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -32,7 +33,7 @@ jobs:
           fetch-depth: 0  # need this for all history for all branches and tags
       - name: Create Release
         id: create_release
-        uses: nickatnight/releases-action@v4
+        uses: nickatnight/releases-action@v5
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +62,8 @@ on:
 
 jobs:
   create-release:
-    permissions: write-all
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -70,7 +72,7 @@ jobs:
           fetch-depth: 0
       - name: Create Release
         id: create_release
-        uses: nickatnight/releases-action@v4
+        uses: nickatnight/releases-action@v5
         if: startsWith(github.ref, 'refs/tags/')
         with:
           branch: "main"


### PR DESCRIPTION
New GH api requires write permissions when creating release. The default token permissions provided by in the runner do not contain write

